### PR TITLE
Fix buffer size error that occurs mainly in Lab7

### DIFF
--- a/arduino/MqttClient/MqttClient.h
+++ b/arduino/MqttClient/MqttClient.h
@@ -13,7 +13,8 @@ class MqttClient
     String get_topic();
     void reset_msg();
   private:
-    MQTTClient _mqtt_client;
+    MQTTClient _mqtt_client{_newBufferSize};
     String *_subscribe_topics;
     int _num_subscribe_topics;
+    static constexpr int _newBufferSize = 1024;
 };


### PR DESCRIPTION
The MQTT client keeps reconnecting in the Arduino running the actuator (subscriber_all) code. The problem shows up when the motion sensor sends massive data. The original buffer size cannot handle the amount of data received, causing overflow and forcing the MQTT client to reconnect.