### PR TITLE
Fix timeout errors that occur mainly in Lab7

### DIFF
--- a/arduino/MqttClient/MqttClient.cpp
+++ b/arduino/MqttClient/MqttClient.cpp
@@ -9,6 +9,8 @@ int _num_subscribe_topics;
 
 MqttClient::MqttClient(const char *mqtt_broker_ip, const int mqtt_broker_port)
 {
+  _mqtt_client.setKeepAlive(5);
+  _mqtt_client.setTimeout(2000);
   _mqtt_client.begin(mqtt_broker_ip, _wifi_client);
 }
 


### PR DESCRIPTION
The added code increases the value of the timer in the MQTT Client, which resets the connection when an MQTT Pong message is not received in time.